### PR TITLE
Adding quotes to URL string to solve some issues with GET paths

### DIFF
--- a/NSURLRequest+AFCurlRequest.m
+++ b/NSURLRequest+AFCurlRequest.m
@@ -38,7 +38,7 @@
         dataString = [NSString stringWithFormat:kCurlFlagData, [[NSString alloc] initWithData:self.HTTPBody encoding:NSUTF8StringEncoding]];
     }
     
-    NSString* request = [NSString stringWithFormat:kCurlFlagRequest, self.HTTPMethod, self.URL.absoluteString];
+    NSString* request = [NSString stringWithFormat:kCurlFlagRequest, self.HTTPMethod, [NSString stringWithFormat:@"\"%@\"", self.URL.absoluteString]];
 
     return [[commandWithHeaders stringByAppendingString:dataString] stringByAppendingString:request];
 }


### PR DESCRIPTION
Hi, thanks for you work, I have used it in to project to help me to debug the network/API problems and to make easier the backend guys to solve the issuer. I ran into a problem with some long GET paths, which is easily solved by adding quotes around the path. This pull request simply adds those quotes